### PR TITLE
Create a global setting for the API key

### DIFF
--- a/com.neil-enns.vatsim-radar.sdPlugin/pi/activateBookmark.html
+++ b/com.neil-enns.vatsim-radar.sdPlugin/pi/activateBookmark.html
@@ -24,12 +24,23 @@
     </sdpi-item>
 
     <sdpi-item label="VATSIM Radar API token">
-      <sdpi-textfield
+      <sdpi-password
         setting="apiToken"
         placeholder="Enter your VATSIM Radar API token"
         global="true"
         required
       />
+    </sdpi-item>
+    <sdpi-item>
+      <div>
+        To obtain an API token visit
+        <span
+          style="color: lightblue; cursor: pointer"
+          onClick="SDPIComponents.streamDeckClient.send('sendToPlugin', {event: 'openApiTokenWebsite'});"
+          aria-label="Open the VATSIM Radar API Token website"
+          >VATSIM Radar</span
+        >.
+      </div>
     </sdpi-item>
   </body>
 </html>

--- a/com.neil-enns.vatsim-radar.sdPlugin/pi/activateBookmark.html
+++ b/com.neil-enns.vatsim-radar.sdPlugin/pi/activateBookmark.html
@@ -22,5 +22,14 @@
         >Refresh</sdpi-button
       >
     </sdpi-item>
+
+    <sdpi-item label="VATSIM Radar API token">
+      <sdpi-textfield
+        setting="apiToken"
+        placeholder="Enter your VATSIM Radar API token"
+        global="true"
+        required
+      />
+    </sdpi-item>
   </body>
 </html>

--- a/src/actions/activateBookmark.ts
+++ b/src/actions/activateBookmark.ts
@@ -1,4 +1,4 @@
-import {
+import streamDeck, {
   action,
   DidReceiveSettingsEvent,
   JsonValue,
@@ -8,6 +8,7 @@ import {
 } from "@elgato/streamdeck";
 import {
   isGetBookmarks,
+  isOpenApiTokenWebsite,
   isRefreshBookmarks,
   SendToPluginMessage,
 } from "@interfaces/sendToPluginMessage";
@@ -51,9 +52,9 @@ export class ActivateBookmark extends SingletonAction<ActivateBookmarkSettings> 
    * Handles requests from the property inspector.
    * @param ev The event.
    */
-  onSendToPlugin(
+  async onSendToPlugin(
     ev: SendToPluginEvent<JsonValue, ActivateBookmarkSettings>
-  ): Promise<void> | void {
+  ): Promise<void> {
     try {
       const message = ev.payload as SendToPluginMessage;
 
@@ -63,7 +64,9 @@ export class ActivateBookmark extends SingletonAction<ActivateBookmarkSettings> 
         return;
       }
 
-      if (isGetBookmarks(message)) {
+      if (isOpenApiTokenWebsite(message)) {
+        await streamDeck.system.openUrl("https://vatsim-radar.com/");
+      } else if (isGetBookmarks(message)) {
         radarManagerInstance.getBookmarks(message.isRefresh);
       } else if (isRefreshBookmarks(message)) {
         radarManagerInstance.getBookmarks(true);

--- a/src/actions/activateBookmark.ts
+++ b/src/actions/activateBookmark.ts
@@ -1,5 +1,6 @@
 import {
   action,
+  DidReceiveSettingsEvent,
   JsonValue,
   KeyDownEvent,
   SendToPluginEvent,
@@ -40,6 +41,12 @@ export class ActivateBookmark extends SingletonAction<ActivateBookmarkSettings> 
     }
   }
 
+  onDidReceiveSettings(
+    ev: DidReceiveSettingsEvent<ActivateBookmarkSettings>
+  ): Promise<void> | void {
+    logger.debug("Received settings", ev.payload.settings);
+  }
+
   /**
    * Handles requests from the property inspector.
    * @param ev The event.
@@ -57,10 +64,8 @@ export class ActivateBookmark extends SingletonAction<ActivateBookmarkSettings> 
       }
 
       if (isGetBookmarks(message)) {
-        logger.debug("Getting bookmarks");
         radarManagerInstance.getBookmarks(message.isRefresh);
       } else if (isRefreshBookmarks(message)) {
-        logger.debug("Refreshing bookmarks");
         radarManagerInstance.getBookmarks(true);
       }
     } catch (error: unknown) {

--- a/src/events/streamdeck/handleReceiveGlobalSettings.ts
+++ b/src/events/streamdeck/handleReceiveGlobalSettings.ts
@@ -1,0 +1,13 @@
+import { DidReceiveGlobalSettingsEvent } from "@elgato/streamdeck";
+import { GlobalSettings } from "@interfaces/globalSettings";
+import radarManagerInstance from "@managers/radar";
+
+/**
+ * Handles global setting updates from property inspectors.
+ * @param ev - The event with the new global settings.
+ */
+export const handleDidReceiveGlobalSettings = (
+  ev: DidReceiveGlobalSettingsEvent<GlobalSettings>
+) => {
+  radarManagerInstance.apiToken = ev.settings.apiToken;
+};

--- a/src/interfaces/globalSettings.ts
+++ b/src/interfaces/globalSettings.ts
@@ -1,0 +1,9 @@
+import { JsonValue } from "@elgato/streamdeck";
+
+/**
+ * Global settings for the plugin.
+ */
+export interface GlobalSettings {
+  apiToken: string | undefined;
+  [key: string]: JsonValue;
+}

--- a/src/interfaces/sendToPluginMessage.ts
+++ b/src/interfaces/sendToPluginMessage.ts
@@ -9,8 +9,19 @@ export interface GetBookmarks {
   [key: string]: JsonValue;
 }
 
+/**
+ * Message sent to the plugin to refresh the bookmarks.
+ */
 export interface RefreshBookmarks {
   event: "refreshBookmarks";
+  [key: string]: JsonValue;
+}
+
+/**
+ * Message sent to the plugin to open the API token website.
+ */
+export interface OpenApiTokenWebsite {
+  event: "openApiTokenWebsite";
   [key: string]: JsonValue;
 }
 
@@ -18,8 +29,12 @@ export interface RefreshBookmarks {
  * Union of all messages sent to the plugin.
  * @see {@link GetBookmarks} for the message to get the bookmarks.
  * @see {@link RefreshBookmarks} for the message to refresh the bookmarks.
+ * @see {@link OpenApiTokenWebsite} for the message to open the API token website.
  **/
-export type SendToPluginMessage = GetBookmarks | RefreshBookmarks;
+export type SendToPluginMessage =
+  | GetBookmarks
+  | RefreshBookmarks
+  | OpenApiTokenWebsite;
 
 /**
  * Typeguard for GetBookmarks.
@@ -41,4 +56,15 @@ export function isRefreshBookmarks(
   message: SendToPluginMessage
 ): message is RefreshBookmarks {
   return message.event === "refreshBookmarks";
+}
+
+/**
+ * Typeguard for OpenApiTokenWebsite.
+ * @param message The message.
+ * @returns True if the message is a OpenApiTokenWebsite message.
+ */
+export function isOpenApiTokenWebsite(
+  message: SendToPluginMessage
+): message is OpenApiTokenWebsite {
+  return message.event === "openApiTokenWebsite";
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -5,6 +5,7 @@ import { ActivateBookmark } from "@actions/activateBookmark";
 import radarManagerInstance from "@managers/radar";
 import { handleBookmarksUpdated } from "./events/radar/bookmarksUpdated";
 import { handleAsyncException } from "./utils/handleAsyncException";
+import { handleDidReceiveGlobalSettings } from "./events/streamdeck/handleReceiveGlobalSettings";
 
 const logger = mainLogger.child({ service: "plugin" });
 
@@ -18,6 +19,7 @@ streamDeck.actions.registerAction(new ActivateBookmark());
 
 // Register event handlers
 radarManagerInstance.on("bookmarksUpdated", handleBookmarksUpdated);
+streamDeck.settings.onDidReceiveGlobalSettings(handleDidReceiveGlobalSettings);
 
 // Finally, connect to the Stream Deck.
 streamDeck


### PR DESCRIPTION
Fixes #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new settings section where users can enter their VATSIM Radar API token for a smoother configuration experience.
  - Enhanced configuration handling so that updates to your token automatically refresh the Radar display, ensuring reliable and up-to-date bookmark management.
  - Introduced functionality to open the VATSIM Radar API Token website for easier access to token management.

- **Bug Fixes**
  - Improved error handling related to missing API tokens during bookmark retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->